### PR TITLE
API for uploading dicoms and segmentations

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -2,7 +2,7 @@ name: Run Unit Tests
 
 on:
   push:
-    branches: [main, fix/*, hotfix/*, release/*, feat/*]
+    branches: [main, fix/*, hotfix/*, release/*]
 
   pull_request:
     branches: [main, fix/*, hotfix/*, release/*, develop]

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,4 +1,4 @@
-name: Run Unit Test via Pytest
+name: Run Unit Tests
 
 on:
   push:

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,0 +1,24 @@
+name: Run Unit Test via Pytest  
+  
+on: [push]  
+
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+    strategy:  
+      matrix:  
+        python-version: ["3.10"] 
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+    - name: Test with pytest
+      run: |
+        pytest tests --junitxml=junit/test-results.xml --cov=datamintapi --cov-report=xml --cov-report=html

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: "pip"
       - name: Install dependencies
         # Install PyTorch cpu version to install faster
         run: |
@@ -30,13 +31,14 @@ jobs:
         run: |
           pytest tests --junitxml=junit/test-results.xml --cov=datamintapi --cov-report=html
       - name: Upload pytest test results
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results
           path: junit/test-results.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
       - name: Upload coverage report
+        # Use always() to always run this step to publish test results when there are test failures
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,24 +1,43 @@
-name: Run Unit Test via Pytest  
-  
-on: [push]  
+name: Run Unit Test via Pytest
 
-jobs:  
-  build:  
-    runs-on: ubuntu-latest  
-    strategy:  
-      matrix:  
-        python-version: ["3.10"] 
+on:
+  push:
+    branches: [main, fix/*, hotfix/*, release/*, feat/*]
+
+  pull_request:
+    branches: [main, fix/*, hotfix/*, release/*, develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[dev]
-    - name: Test with pytest
-      run: |
-        pytest tests --junitxml=junit/test-results.xml --cov=datamintapi --cov-report=xml --cov-report=html
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        # Install PyTorch cpu version to install faster
+        run: |
+          python -m pip install --upgrade pip
+          pip install "torch>=1.2" "torchvision>=0.12" --index-url https://download.pytorch.org/whl/cpu
+          pip install .[dev]
+      - name: Test with pytest
+        run: |
+          pytest tests --junitxml=junit/test-results.xml --cov=datamintapi --cov-report=html
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: junit/test-results.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,178 +1,45 @@
 # Datamint python API
 
-## Installation
-Install via pip: `pip install git+https://github.com/SonanceAI/datamint-python-api`.
+See the full documentation at https://sonanceai.github.io/datamint-python-api/
 
-## Setup API key
-> [!NOTE]
-> Not required if you don't plan to communicate with the server.
+Installation
+------------
 
-There are three options to specify the API key:
-1. Specify API key as an enviroment variable:
-  - **command line:** `export DATAMINT_API_KEY="my_api_key"; python my_script.py` 
-  - **python:** `os.environ["DATAMINT_API_KEY"] = "my_api_key"`
-2. Specify API key in the API Handler constructor:
+Datamint requires Python 3.8+. You can install Datamint and its
+dependencies using pip
+
+``` {.bash}
+pip install git+https://github.com/SonanceAI/datamint-python-api
+```
+
+Soon we will be releasing the package on PyPi. We strongly recommend
+that you install Datamint in a dedicated virtualenv, to avoid
+conflicting with your system packages.
+
+Setup API key
+-------------
+
+There are two options to specify the API key:
+
+1.  Specify API key as an environment variable:
+```bash
+export DATAMINT_API_KEY="my_api_key" python my_script.py
+```
+
+```python
+os.environ["DATAMINT_API_KEY"] = "my_api_key"
+```
+
+2.  Specify API key in the
+    :py`APIHandler <datamintapi.api_handler.APIHandler>`{.interpreted-text
+    role="class"} constructor:
+
 ```python
 from datamintapi import APIHandler
-
 api_handler = APIHandler(api_key='my_api_key')
 ```
-3. run `datamint config`? (TODO?) and follow the instructions?
 
-## API Usage
+Other functionalities
+---------------------
 
-Import the APIHandler class and create an instance: `api_handler = APIHandler()`
-
-### Upload dicoms
-
-#### Examples:
-
-##### Upload a single dicom file
-```python
-batch_id = "abcd1234"
-file_path = "/path/to/dicom.dcm"
-dicom_id = api_handler.upload_dicom(batch_id, file_path)
-```
-
-##### Upload dicom, anonymize it and add label 'pneumonia' to it
-```python
-batch_id = "abcd1234"
-file_path = "/path/to/dicom.dcm"
-dicom_id = api_handler.upload_dicom(batch_id, 
-                                    file_path,
-                                    anonymize=True,
-                                    labels=['pneumonia'])
-```
-
-#### Upload multiple dicoms and create a new batch
-```python
-api_handler.create_new_batch(description='CT scans',
-                             file_path='/path/to/dicom_files/',
-                             mung_filename='all', # This will convert files name to 'path_to_dicom_files/1.dcm', 'path_to_dicom_files/2.dcm', etc.
-                             ):
-```
-
-
-
-### Dataset
-Import the custom dataset class and create an instance: 
-```python 
-from datamintapi import Dataset
-
-dataset = Dataset(root='../data',
-                  dataset_name='TestCTdataset',
-                  version='latest',
-                  api_key='my_api_key'
-                )
-```
-and then use it in your PyTorch code as usual.
-
-#### Test
-Go to DatamintAPI directory and run `dataset.py`
-```bash
-cd datamintapi; python dataset.py
-```
-
-#### Examples
-Here are some examples on how to use the custom dataset class:
-
-##### Pytorch
-
-Inheriting datamint [`Dataset`](datamintapi/dataset.py):
-```python
-import datamintapi
-import torch
-from torchvision.transforms import ToTensor
-from torch.utils.data import DataLoader
-
-
-class XrayFractureDataset(datamintapi.Dataset):
-    def __getitem__(self, idx):
-        image, dicom_metainfo, metainfo = super().__getitem__(idx)
-
-        # Get all relevant information from the dicom_metainfo object
-        patient_sex = dicom_metainfo.PatientSex
-
-        # Get all relevant information from the metainfo object
-        has_fracture = 'fracture' in metainfo['labels']
-        has_fracture = torch.tensor(has_fracture, dtype=torch.int32)
-
-        return image, patient_sex, has_fracture
-
-
-# Create an instance of your custom dataset
-dataset = XrayFractureDataset(root='data',
-                              dataset_name='YOUR_DATASET_NAME',
-                              version='latest',
-                              api_key='my_api_key',
-                              transform=ToTensor()
-                              )
-
-# Create a DataLoader to handle batching and shuffling of the dataset
-dataloader = DataLoader(dataset,
-                        batch_size=4,
-                        shuffle=True)
-
-for images, patients_sex, labels in dataloader:
-    images = images.to(device)
-    # labels will already be a tensor of shape (batch_size,) containing 0s and 1s
-
-    # (...) do something with the batch
-```
-
-Alternative:
-```python
-import datamintapi
-import torch
-from torchvision.transforms import ToTensor
-from torch.utils.data import DataLoader
-
-
-# Set the device
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
-
-# Create an instance of the datamintapi.Dataset
-dataset = datamintapi.Dataset(root='data',
-                              dataset_name='TestCTdataset',
-                              version='latest',
-                              api_key='my_api_key',
-                              transform=ToTensor()
-                              )
-
-# This function tells the dataloader how to group the items in a batch
-
-
-def collate_fn(batch):
-    images = [item[0] for item in batch]
-    dicom_metainfo = [item[1] for item in batch]
-    metainfo = [item[2] for item in batch]
-
-    return torch.stack(images), dicom_metainfo, metainfo
-
-
-# Create a DataLoader to handle batching and shuffling of the dataset
-dataloader = DataLoader(dataset,
-                        batch_size=4,
-                        collate_fn=collate_fn,
-                        shuffle=True)
-
-for images, dicom_metainfo, metainfo in dataloader:
-    images = images.to(device)
-    metainfo = metainfo
-
-    # (... do something with the batch)
-```
-
-## Command-line Usage
-### datamint-upload
-Upload a single dicom file:
-```bash
-datamint-upload --path data/dicom_file.dcm
-```
-
-Upload all dicom files inside a directory and all its subdirectories, recursively:
-```bash
-datamint-upload --path data/dicom_files/ -r
-```
-(...)
+See the full documentation at https://sonanceai.github.io/datamint-python-api/

--- a/datamintapi/api_handler.py
+++ b/datamintapi/api_handler.py
@@ -1,4 +1,4 @@
-from typing import Optional, IO, Sequence, Literal
+from typing import Optional, IO, Sequence, Literal, Generator
 import os
 from requests import Session
 from requests.exceptions import HTTPError
@@ -354,6 +354,37 @@ class APIHandler:
                                                                     mung_filename=mung_filename)
                                           )
         return batch_id, results
+
+    def get_batches(self) -> Generator[dict, None, None]:
+        """
+        Iterate over all the batches.
+
+        Returns:
+            Generator[dict, None, None]: A generator of dictionaries with information about the batches.
+
+        Example:
+            >>> for batch in api_handler.get_batches():
+            >>>     print(batch)
+        """
+
+        offset = 0
+        limit_page = 10
+
+        request_params = {
+            'method': 'GET',
+            'params': {'offset': offset, 'limit': limit_page},
+            'url': f'{self.root_url}/upload-batches'
+        }
+
+        results = self._run_request(request_params).json()['data']
+        while len(results) > 0:
+            for result in results:
+                yield result
+            if len(results) < limit_page:
+                break
+            offset += limit_page
+            request_params['params']['offset'] = offset
+            results = self._run_request(request_params).json()['data']
 
     def get_batch_info(self, batch_id: str) -> dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ sphinx = { version = ">=5.0", optional = true }
 sphinx_rtd_theme = { version = ">=2.0.0", optional = true }
 sphinx-tabs = { version = ">=3.0.0", optional = true }
 setuptools = { version = ">=57.0", optional = true }
+# Extra dependencies for dev
+pytest = { version = "^7.0.0", optional = true }
+pytest-cov = { version = "^4.0.0", optional = true }
+responses = { version = "^0.20.0", optional = true }
+aioresponses = { version = "^0.7.0", optional = true }
 
 
 [tool.poetry.dev-dependencies]
@@ -37,6 +42,7 @@ aioresponses = "^0.7.0"
 # Extra dependencies for docs
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinx-tabs", "setuptools"]
+dev = ["pytest", "pytest-cov", "responses", "aioresponses"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ aiohttp = "^3.0.0"
 nest-asyncio = "^1.0.0"
 humanize = "^4.0.0"
 rich = ">=10.0.0"
+nibabel = ">=4.0.0"
 # Extra dependencies for docs
 sphinx = { version = ">=5.0", optional = true }
 sphinx_rtd_theme = { version = ">=2.0.0", optional = true }

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -112,11 +112,11 @@ class TestAPIHandler:
         def _request_callback(url, data, **kwargs):
             assert data['filepath'] == '__data_test_dicom.dcm'
             return CallbackResult(status=201, payload={"id": "newdicomid"})
-        
+
         def _request_callback2(url, data, **kwargs):
             assert data['filepath'] == 'data/test_dicom.dcm'
             return CallbackResult(status=201, payload={"id": "newdicomid"})
-        
+
         def _request_callback3(url, data, **kwargs):
             assert data['filepath'] == 'me_data_test_dicom.dcm'
             return CallbackResult(status=201, payload={"id": "newdicomid"})
@@ -142,9 +142,9 @@ class TestAPIHandler:
                     callback=_request_callback2
                 )
                 new_dicoms_id = api_handler.upload_dicoms(batch_id=batch_id,
-                                                        files_path='data/test_dicom.dcm',
-                                                        anonymize=False,
-                                                        mung_filename=None)
+                                                          files_path='data/test_dicom.dcm',
+                                                          anonymize=False,
+                                                          mung_filename=None)
                 assert len(new_dicoms_id) == 1 and new_dicoms_id[0] == 'newdicomid'
 
             with aioresponses() as mock_aioresp:
@@ -153,9 +153,9 @@ class TestAPIHandler:
                     callback=_request_callback3
                 )
                 new_dicoms_id = api_handler.upload_dicoms(batch_id=batch_id,
-                                                        files_path='/home/me/data/test_dicom.dcm',
-                                                        anonymize=False,
-                                                        mung_filename=[2,3])
+                                                          files_path='/home/me/data/test_dicom.dcm',
+                                                          anonymize=False,
+                                                          mung_filename=[2, 3])
                 assert len(new_dicoms_id) == 1 and new_dicoms_id[0] == 'newdicomid'
 
     @responses.activate
@@ -218,3 +218,34 @@ class TestAPIHandler:
         # Test non existing batch
         with pytest.raises(ResourceNotFoundError):
             api_handler.get_batch_info('non_existing_batch_id')
+
+    @responses.activate
+    def test_get_batches(self):
+        api_handler = APIHandler(_TEST_URL, 'test_api_key')
+
+        batches_data = [
+            {"id": "batch1", "description": "Batch 1"},
+            {"id": "batch2", "description": "Batch 2"},
+            {"id": "batch3", "description": "Batch 3"}
+        ]
+        responses.get(
+            f"{_TEST_URL}/upload-batches",
+            json={"data": batches_data},
+            status=200,
+        )
+
+        batches = list(api_handler.get_batches())
+        assert len(batches) == 3
+
+    @responses.activate
+    def test_get_batches_no_batch(self):
+        api_handler = APIHandler(_TEST_URL, 'test_api_key')
+
+        responses.get(
+            f"{_TEST_URL}/upload-batches",
+            json={"data": []},
+            status=200,
+        )
+
+        batches = list(api_handler.get_batches())
+        assert len(batches) == 0


### PR DESCRIPTION
Related task: DAT-108

What it is new:
- Workflow for running automated tests
- The README now only contains an introduction and points to the full documentation in GitHub pages. 
- An error `ResourceNotFoundError` is now raised when a dicom is not found at the server, instead of an ugly error.
- New methods: `upload_segmentation` and `get_batches`.
- Fixed an issue when using `mung_filename='all'`.
- Fixed an issue when uploading a single file.