### PR TITLE
Feat/upload segmentations

### DIFF
--- a/docs/source/client_api.rst
+++ b/docs/source/client_api.rst
@@ -178,8 +178,8 @@ To upload a segmentation, use the :py:meth:`upload_segmentation() <datamintapi.a
 
 .. code-block:: python
     
-    batch_id, dicoms_ids = api_handler.create_batch_with_dicoms('New batch', 'path/to/dicom.dcm')
-    api_handler.upload_segmentation(dicoms_ids[0], 'path/to/segmentation.nifti', 'Segmentation name')
+    resource_id = api_handler.upload_resources("/path/to/dicom1.dcm") # or use an existing resource_id
+    api_handler.upload_segmentation(resource_id, 'path/to/segmentation.nifti', 'SegmentationName')
 
 
 Dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "DatamintAPI"
-version = "0.4.0"
+version = "0.5.0"
 description = "A library for loading Datamint datasets into Pytorch"
 authors = ["Sonance Team"]
 readme = "README.md"


### PR DESCRIPTION
**Task:** DAT-316

This PR implements method `upload_segmentations` and adds parameter `segmentation_files` in method `upload_resources` to upload segmentations along with the resources.

```python
    def upload_segmentations(self,
                             resource_id: str,
                             file_path: str,
                             name: Optional[Union[str, Dict[int, str]]] = None,
                             frame_index: int = None,
                             discard_empty_segmentations: bool = True
                             ) -> str:
        """
        Upload segmentations to a resource.

        Args:
            resource_id (str): The resource unique id.
            file_path (str): The path to the segmentation file.
            name (Optional[Union[str, Dict[int, str]]]): The name of the segmentation or a dictionary mapping pixel values to names 
                example: {1: 'Femur', 2: 'Tibia'}.
            frame_index (int): The frame index of the segmentation.
            discard_empty_segmentations (bool): Whether to discard empty segmentations or not.

        Returns:
            str: The segmentation unique id.

        Raises:
            ResourceNotFoundError: If the resource does not exists or the segmentation is invalid.

        Example:
            >>> api_handler.upload_segmentation(resource_id, 'path/to/segmentation.png', 'SegmentationName')
        """
```