### PR TITLE
One-line trainer for classification (DAT-949)

### DIFF
--- a/datamint/lightning/trainers/__init__.py
+++ b/datamint/lightning/trainers/__init__.py
@@ -6,7 +6,7 @@ from .seg2d_trainer import SemanticSegmentation2DTrainer
 from .seg3d_trainer import SemanticSegmentation3DTrainer
 from .classification_trainer import ClassificationTrainer, ImageClassificationTrainer
 from .detection_trainer import DetectionTrainer
-from .specialized import UNetPPTrainer, DeepLabV3PlusTrainer, TransUNetTrainer, UNETRPPTrainer, NNUNetTrainer, YOLOXTrainer
+from .specialized import UNetPPTrainer, DeepLabV3PlusTrainer, TransUNetTrainer, UNETRPPTrainer, NNUNetTrainer, YOLOXTrainer, EfficientNetV2Trainer
 from .vol_seg_trainer import VolumeSegmentationTrainer
 
 __all__ = [
@@ -23,5 +23,6 @@ __all__ = [
     "ImageClassificationTrainer",
     "NNUNetTrainer",
     "YOLOXTrainer",
+    "EfficientNetV2Trainer",
     "DetectionTrainer"
 ]

--- a/datamint/lightning/trainers/specialized/__init__.py
+++ b/datamint/lightning/trainers/specialized/__init__.py
@@ -4,6 +4,7 @@ from .transunet import TransUNetTrainer
 from .unetrpp import UNETRPPTrainer
 from .nnunet.trainer import NNUNetTrainer
 from .yolox import YOLOXTrainer
+from .efficientnetv2 import EfficientNetV2Trainer
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "UNETRPPTrainer",
     "NNUNetTrainer",
     "YOLOXTrainer",
+    "EfficientNetV2Trainer",
 ]

--- a/datamint/lightning/trainers/specialized/efficientnetv2.py
+++ b/datamint/lightning/trainers/specialized/efficientnetv2.py
@@ -1,0 +1,53 @@
+"""EfficientNetV2 image classification trainer."""
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+from typing_extensions import override
+
+from ..classification_trainer import ImageClassificationTrainer
+
+if TYPE_CHECKING:
+    from albumentations import BaseCompose
+
+
+class EfficientNetV2Trainer(ImageClassificationTrainer):
+    """Trainer pre-configured for EfficientNetV2.
+
+    Default model: **EfficientNetV2-S** pretrained on ImageNet at 384×384.
+    
+    Args:
+        model_name: ``timm`` model name. Defaults to ``'efficientnetv2_s'``.
+            Other valid choices: ``'efficientnetv2_m'``, ``'efficientnetv2_l'``,
+            ``'efficientnetv2_xl'``, ``'efficientnetv2_rw_t'``.
+        image_size: Target image size ``(H, W)`` or a single int for square
+            images. Defaults to ``384``, the resolution EfficientNetV2-S was
+            trained at.
+
+    Example::
+
+        trainer = EfficientNetV2Trainer(project='ChestXray')
+        results = trainer.fit()
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str = 'efficientnetv2_s',
+        image_size: int | tuple[int, int] = 384,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(model_name=model_name, image_size=image_size, **kwargs)
+
+    @override
+    def _train_transform(self) -> 'BaseCompose':
+        import albumentations as A
+        from albumentations.pytorch import ToTensorV2
+
+        return A.Compose([
+            self._build_resize_transform(),
+            A.ToRGB(),
+            A.HorizontalFlip(p=0.5),
+            A.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1, p=0.5),
+            A.Normalize(),
+            ToTensorV2(),
+        ])


### PR DESCRIPTION
Added EfficientNETV2Trainer.

DAT-950 is created from this task, since the FracAtlas notebook is using some things we've updated, DAT-950 will contain an use-case of this model.

Closes DAT-949.