### PR TITLE
Expose AnnotationsSpecs in DatamintModel so we know which annotationsspecs it predicts (DAT-955)

### DIFF
--- a/datamint/lightning/trainers/base_trainer.py
+++ b/datamint/lightning/trainers/base_trainer.py
@@ -325,6 +325,16 @@ class BaseTrainer(ABC):
         """Build a DatamintModel deployment adapter.  Override in subclasses."""
         return None
 
+    def _build_annotation_specs(self) -> list | None:
+        """Return annotation specs describing what this model predicts.
+
+        Override in task-specific subclasses to return the appropriate
+        list of :class:`~datamint.entities.annotations.annotation_spec.AnnotationSpec`
+        objects derived from the dataset.  Returns ``None`` by default,
+        which means no annotation specs will be saved with the model.
+        """
+        return None
+
     # ── Concrete helpers ────────────────────────────────────────
 
     def _resolve_dataset(self) -> DatamintBaseDataset:
@@ -378,15 +388,18 @@ class BaseTrainer(ABC):
         _LOGGER.debug("Using %s for model checkpointing with monitor='%s' mode='%s'",
                       checkpoint_cls.__name__, metric_name, mode)
 
-        callbacks: list = [
-            checkpoint_cls(
-                monitor=metric_name,
-                mode=mode,
-                save_top_k=1,
-                register_model_name=model_name,
-                register_model_on='test',
-                log_model_metrics=True,  # TODO: move this functionality to a separate callback or here
-            )]
+        checkpoint_kwargs: dict[str, Any] = dict(
+            monitor=metric_name,
+            mode=mode,
+            save_top_k=1,
+            register_model_name=model_name,
+            register_model_on='test',
+            log_model_metrics=True,
+        )
+        if checkpoint_cls is MLFlowDatamintModelCheckpoint:
+            checkpoint_kwargs['annotation_specs'] = self._build_annotation_specs()
+
+        callbacks: list = [checkpoint_cls(**checkpoint_kwargs)]
 
         callbacks.append(_LogDatasetSplitsCallback(self))
 

--- a/datamint/lightning/trainers/classification_trainer.py
+++ b/datamint/lightning/trainers/classification_trainer.py
@@ -10,6 +10,8 @@ from torch import nn
 from datamint.dataset import ImageDataset
 from functools import partial
 
+from datamint.entities.annotations.annotation_spec import CategoryAnnotationSpec
+from datamint.entities.annotations.types import AnnotationType
 from .lightning_modules import ClassificationModule
 from .base_trainer import BaseTrainer
 
@@ -42,6 +44,21 @@ class ClassificationTrainer(BaseTrainer):
 
     def _monitor_metric(self) -> tuple[str, str]:
         return 'val/accuracy', 'max'
+
+    def _build_annotation_specs(self) -> list[CategoryAnnotationSpec]:
+        groups: dict[str, list[str]] = {}
+        for identifier, value in self.dataset.image_categories_set:
+            groups.setdefault(identifier, []).append(value)
+        return [
+            CategoryAnnotationSpec(
+                type=AnnotationType.CATEGORY,
+                scope='image',
+                identifier=ident,
+                required=True,
+                values=sorted(vals),
+            )
+            for ident, vals in groups.items()
+        ]
 
 
 class ImageClassificationTrainer(ClassificationTrainer):

--- a/datamint/lightning/trainers/detection_trainer.py
+++ b/datamint/lightning/trainers/detection_trainer.py
@@ -8,6 +8,8 @@ from torch import nn
 
 from datamint.dataset.image_dataset import ImageDataset, detection_collate_fn
 from datamint.lightning.datamodule import DatamintDataModule
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
+from datamint.entities.annotations.types import AnnotationType
 from .base_trainer import BaseTrainer
 
 if TYPE_CHECKING:
@@ -64,3 +66,9 @@ class DetectionTrainer(BaseTrainer):
 
     def _monitor_metric(self) -> tuple[str, str]:
         return 'val/map', 'max'
+
+    def _build_annotation_specs(self) -> list[AnnotationSpec]:
+        return [
+            AnnotationSpec(type=AnnotationType.SQUARE, scope='image', identifier=name, required=False)
+            for name in self.dataset.box_labels_set
+        ]

--- a/datamint/lightning/trainers/segmentation_trainer.py
+++ b/datamint/lightning/trainers/segmentation_trainer.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
+from datamint.entities.annotations.types import AnnotationType
 from .base_trainer import BaseTrainer
 
 
@@ -56,3 +58,9 @@ class SegmentationTrainer(BaseTrainer):
 
     def _monitor_metric(self) -> tuple[str, str]:
         return 'val/iou', 'max'
+
+    def _build_annotation_specs(self) -> list[AnnotationSpec]:
+        return [
+            AnnotationSpec(type=AnnotationType.SEGMENTATION, scope='image', identifier=name, required=False)
+            for name in self.dataset.seglabel_list
+        ]

--- a/datamint/lightning/trainers/specialized/nnunet/trainer.py
+++ b/datamint/lightning/trainers/specialized/nnunet/trainer.py
@@ -13,6 +13,8 @@ from rich import print as rprint
 from datamint.lightning.trainers.base_trainer import BaseTrainer
 from datamint.dataset.volume_dataset import VolumeDataset
 from datamint.lightning.trainers.specialized.nnunet.data_export import DatamintToNNUNetExporter
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
+from datamint.entities.annotations.types import AnnotationType
 
 if TYPE_CHECKING:
     from datamint.entities import Project
@@ -86,6 +88,19 @@ class NNUNetTrainer(BaseTrainer):
 
     def _build_dataset(self, project: 'str | Project', **kwargs) -> VolumeDataset:
         return VolumeDataset(project=project, **kwargs)
+
+    def _build_annotation_specs(self) -> list[AnnotationSpec]:
+        from datamint.dataset import VolumeDataset
+        ds = VolumeDataset(
+            project=self._user_project,
+            return_as_semantic_segmentation=True,
+            allow_external_annotations=True,
+            include_unannotated=False,
+        )
+        return [
+            AnnotationSpec(type=AnnotationType.SEGMENTATION, scope='volume', identifier=name, required=False)
+            for name in ds.seglabel_list
+        ]
 
     def _build_model(self, *args, **kwargs):
         raise NotImplementedError(

--- a/datamint/lightning/trainers/vol_seg_trainer.py
+++ b/datamint/lightning/trainers/vol_seg_trainer.py
@@ -15,6 +15,8 @@ from albumentations.pytorch import ToTensorV2
 from datamint.dataset import VolumeDataset
 from datamint.lightning.datamodule import DatamintDataModule
 
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
+from datamint.entities.annotations.types import AnnotationType
 from .segmentation_trainer import SegmentationTrainer
 
 if TYPE_CHECKING:
@@ -158,3 +160,9 @@ class VolumeSegmentationTrainer(SegmentationTrainer):
             eval_transform=eval_transform,
             pin_memory=False,
         )
+
+    def _build_annotation_specs(self) -> list[AnnotationSpec]:
+        return [
+            AnnotationSpec(type=AnnotationType.SEGMENTATION, scope='volume', identifier=name, required=False)
+            for name in self.dataset.seglabel_list
+        ]

--- a/datamint/mlflow/flavors/datamint_flavor.py
+++ b/datamint/mlflow/flavors/datamint_flavor.py
@@ -7,6 +7,7 @@ import datamint.mlflow.flavors
 from mlflow import pyfunc
 from .model import BaseDatamintModel, DatamintModel, _DatamintModelWrapper
 from .task_type import TaskType
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
 from collections.abc import Sequence
 from dataclasses import asdict
 from packaging.requirements import Requirement
@@ -207,6 +208,7 @@ def save_model(datamint_model: BaseDatamintModel,
                path,
                task_type: TaskType | str | None = None,
                supported_modes: Sequence[str] | None = None,
+               annotation_specs: Sequence[AnnotationSpec] | None = None,
                data_path=None,
                code_paths=None,
                infer_code_paths=False,
@@ -259,12 +261,14 @@ def save_model(datamint_model: BaseDatamintModel,
     linked_models = datamint_model._get_linked_models_uri() if hasattr(datamint_model, '_get_linked_models_uri') else {}
     resolved_task_type = task_type or getattr(datamint_model, 'task_type', None)
     task_type_value = resolved_task_type.value if isinstance(resolved_task_type, TaskType) else resolved_task_type
+    resolved_specs = annotation_specs or getattr(datamint_model, 'annotation_specs', None)
     flavor_params = {
         "datamint_version": datamint.__version__,
         "supported_modes": supported_modes or datamint_model.get_supported_modes(),
         "model_settings": asdict(datamint_model.settings),
         "linked_models": linked_models,
         "task_type": task_type_value,
+        "annotation_specs": [s.model_dump(mode='json', warnings='none', exclude_none=True) for s in resolved_specs] if resolved_specs else None,
     }
     mlflow_model.add_flavor(FLAVOR_NAME, **flavor_params)
     model_config.update(flavor_params)
@@ -332,6 +336,7 @@ def log_model(
     datamint_model: BaseDatamintModel,
     task_type: TaskType | str | None = None,
     supported_modes: Sequence[str] | None = None,
+    annotation_specs: Sequence[AnnotationSpec] | None = None,
     name: str = "datamint_model",
     data_path=None,
     code_paths=None,
@@ -351,6 +356,7 @@ def log_model(
         datamint_model=datamint_model,
         task_type=task_type,
         supported_modes=supported_modes,
+        annotation_specs=annotation_specs,
         name=name,
         flavor=datamint.mlflow.flavors.datamint_flavor,
         data_path=data_path,
@@ -386,17 +392,23 @@ def _load_pyfunc(path: str, model_config=None) -> pyfunc.PyFuncModel:
         dt_model = dt_model.another_model
         pf_model._model_impl.python_model = dt_model
 
-    # Restore task_type from flavor metadata if not already set on the model
-    if not dt_model.task_type:
+    # Restore task_type and annotation_specs from flavor metadata if not already set on the model
+    if not dt_model.task_type or not dt_model.annotation_specs:
         try:
             mlflow_model_meta = Model.load(path)
             flavor_data = mlflow_model_meta.flavors.get(FLAVOR_NAME, {})
-            task_type_str = flavor_data.get('task_type')
-            if task_type_str:
-                dt_model.task_type = TaskType(task_type_str)
-        except ValueError:
-            logger.warning(f"Unknown task_type in flavor metadata: {task_type_str}")
+            if not dt_model.task_type:
+                task_type_str = flavor_data.get('task_type')
+                if task_type_str:
+                    try:
+                        dt_model.task_type = TaskType(task_type_str)
+                    except ValueError:
+                        logger.warning(f"Unknown task_type in flavor metadata: {task_type_str}")
+            if not dt_model.annotation_specs:
+                raw_specs = flavor_data.get('annotation_specs')
+                if raw_specs:
+                    dt_model.annotation_specs = [AnnotationSpec.create(**s) for s in raw_specs]
         except Exception as e:
-            logger.debug(f"Could not restore task_type from flavor metadata: {e}")
+            logger.debug(f"Could not restore metadata from flavor: {e}")
 
     return pf_model

--- a/datamint/mlflow/flavors/model.py
+++ b/datamint/mlflow/flavors/model.py
@@ -13,6 +13,7 @@ import torch
 from typing_extensions import override
 
 from datamint.entities.annotations import Annotation, ImageSegmentation, ImageClassification
+from datamint.entities.annotations.annotation_spec import AnnotationSpec
 from datamint.entities.resource import BaseResource
 from datamint.entities.resources.volume_resource import VolumeResource
 from datamint.entities.sliced_resource import SlicedVolumeResource
@@ -69,6 +70,10 @@ class BaseDatamintModel(PythonModel, ABC):
     task_type: ClassVar[TaskType | None] = None
     """Semantic task category for this model class. Subclasses should override
     at the class body level (e.g. ``task_type = TaskType.IMAGE_SEGMENTATION``)."""
+
+    annotation_specs: ClassVar[list[AnnotationSpec] | None] = None
+    """Annotation specs this model produces. Subclasses can override at the class body level.
+    When ``None``, specs may be provided via ``log_model``/``save_model`` instead."""
 
     def __init__(
         self,

--- a/datamint/mlflow/lightning/callbacks/modelcheckpoint.py
+++ b/datamint/mlflow/lightning/callbacks/modelcheckpoint.py
@@ -676,6 +676,10 @@ class MLFlowDatamintModelCheckpoint(_BaseMLFlowModelCheckpoint):
     so no forward-wrapping is performed.
     """
 
+    def __init__(self, *args, annotation_specs: list | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.annotation_specs = annotation_specs
+
     @override
     def log_model_to_mlflow(self,
                             model: 'nn.Module | L.LightningModule | BaseDatamintModel',
@@ -698,6 +702,7 @@ class MLFlowDatamintModelCheckpoint(_BaseMLFlowModelCheckpoint):
             model,
             name=Path(self._last_checkpoint_saved).stem,
             signature=self._inferred_signature,
+            annotation_specs=self.annotation_specs,
             run_id=run_id,
             extra_pip_requirements=self._build_requirements(),
             code_paths=self.code_paths,


### PR DESCRIPTION
- Added annotation_specs to BaseDatamintModel.
- Added _build_annotation_specs().
-  save_model/log_model now accept annotation_specs.
-  Tested with the models (since nnU-Net is a bit different from other models we had to change the logic there).

Closes DAT-955.