### PR TITLE
DatamintModel with default implementations for `predict_volume`, ..., based on the implementation of `predict_slice` (DAT-828)

### DIFF
--- a/datamint/entities/sliced_resource.py
+++ b/datamint/entities/sliced_resource.py
@@ -95,6 +95,19 @@ class SlicedVolumeResource(SlicedResourceBase):
     def _slice_cache_entity_id(self) -> str:
         return f"{self._parent.id}:axis{self.slice_axis}:slice{self.slice_index}"
 
+    def fetch_file_data(self, auto_convert: bool = False, use_cache: bool = False) -> np.ndarray:
+        """Return the 2D slice as an (H, W) or (H, W, C) numpy array.
+
+        Overrides the parent delegation so that image models calling
+        ``fetch_file_data`` on a sliced proxy get the 2D slice, not the
+        full 3D volume.
+        """
+        sliced = self.fetch_slice_data()  # (C, H, W)
+        hwc = np.moveaxis(sliced, 0, -1)  # (H, W, C)
+        if hwc.shape[-1] == 1:
+            hwc = hwc[..., 0]  # (H, W) for single-channel
+        return hwc
+
     def fetch_slice_data(self) -> np.ndarray:
         """Fetch the 2D slice as a (C, H, W) array.
 

--- a/datamint/entities/sliced_resource_base.py
+++ b/datamint/entities/sliced_resource_base.py
@@ -33,9 +33,9 @@ class SlicedResourceBase:
     def _get_version_info(self) -> dict:
         """Get version info from the parent resource for cache validation."""
         return {
-            'created_at': self._parent.created_at,
-            'deleted_at': self._parent.deleted_at,
-            'size': self._parent.size,
+            'created_at': getattr(self._parent, 'created_at', None),
+            'deleted_at': getattr(self._parent, 'deleted_at', None),
+            'size': getattr(self._parent, 'size', None),
         }
 
     @cached_property

--- a/datamint/mlflow/flavors/model.py
+++ b/datamint/mlflow/flavors/model.py
@@ -17,9 +17,10 @@ from datamint.entities.annotations.annotation_spec import AnnotationSpec
 from datamint.entities.resource import BaseResource
 from datamint.entities.resources.volume_resource import VolumeResource
 from datamint.entities.sliced_resource import SlicedVolumeResource
+from datamint.entities.sliced_video_resource import SlicedVideoResource
 from datamint.mlflow.flavors.model_loader import LINKED_MODELS_DIR as DEFAULT_LINKED_MODELS_DIR
 from datamint.mlflow.flavors.model_loader import LinkedModelLoader
-from datamint.mlflow.flavors.prediction_router import PredictionRouter
+from datamint.mlflow.flavors.prediction_router import PredictionRouter, bridge_mode
 from datamint.mlflow.flavors.task_type import TaskType
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,7 @@ class BaseDatamintModel(PythonModel, ABC):
     def predict_image(self, model_input: list[BaseResource], **kwargs: Any) -> PredictionImageResult:
         raise NotImplementedError("predict_image is not implemented")
 
+    @bridge_mode
     def predict_slice(
         self,
         model_input: list[BaseResource],
@@ -247,10 +249,57 @@ class BaseDatamintModel(PythonModel, ABC):
         axis: ViewPlane,
         **kwargs: Any,
     ) -> PredictionImageResult:
+        """Process a single volume slice through :meth:`predict_image`."""
+        if "image" in self.get_supported_modes():
+            image_inputs = []
+            for r in model_input:
+                if isinstance(r, SlicedVolumeResource):
+                    image_inputs.append(r)
+                elif isinstance(r, VolumeResource) or (hasattr(r, 'is_volume') and r.is_volume()):
+                    image_inputs.append(SlicedVolumeResource(r, slice_index=slice_index, slice_axis=axis))
+                else:
+                    raise ValueError(f"Unsupported resource type for slice prediction: {type(r)}")
+            return self.predict_image(image_inputs, **kwargs)
         raise NotImplementedError("predict_slice is not implemented")
 
+    @bridge_mode
     def predict_volume(self, model_input: list[BaseResource], **kwargs: Any) -> PredictionResult:
+        """Process each volume by iterating axial slices through :meth:`predict_slice`."""
+        if "slice" in self.get_supported_modes():
+            axis: ViewPlane = 'axial'
+            results = []
+            for resource in model_input:
+                slices = SlicedVolumeResource.slice_over(resource, slice_axis=axis)
+                resource_anns: list = []
+                for sliced in slices:
+                    preds = self.predict_slice([sliced], slice_index=sliced.slice_index, axis=axis, **kwargs)
+                    resource_anns.extend(preds[0])
+                results.append(resource_anns)
+            return results
         raise NotImplementedError("predict_volume is not implemented")
+
+    @bridge_mode
+    def predict_frame(self, model_input: list[BaseResource], frame_index: int, **kwargs: Any) -> PredictionImageResult:
+        """Process a single video frame through :meth:`predict_image`."""
+        if "image" in self.get_supported_modes():
+            frame_inputs = [SlicedVideoResource(r, frame_index=frame_index) for r in model_input]
+            return self.predict_image(frame_inputs, **kwargs)
+        raise NotImplementedError("predict_frame is not implemented")
+
+    @bridge_mode
+    def predict_all_frames(self, model_input: list[BaseResource], **kwargs: Any) -> PredictionResult:
+        """Process all video frames independently through :meth:`predict_image`."""
+        if "image" in self.get_supported_modes():
+            results = []
+            for resource in model_input:
+                frames = SlicedVideoResource.slice_over(resource)
+                resource_anns: list = []
+                for frame in frames:
+                    preds = self.predict_image([frame], **kwargs)
+                    resource_anns.extend(preds[0])
+                results.append(resource_anns)
+            return results
+        raise NotImplementedError("predict_all_frames is not implemented")
 
 
 class DatamintModel(BaseDatamintModel):
@@ -380,39 +429,6 @@ class DatamintModel(BaseDatamintModel):
 
     def _clear_ptmodel(self) -> None:
         self._set_ptmodel(None)
-
-    # ------------------------------------------------------------------
-    # Prediction dispatch overrides
-    # ------------------------------------------------------------------
-
-    @override
-    def predict_slice(
-        self,
-        model_input: list[BaseResource],
-        slice_index: int,
-        axis: ViewPlane,
-        **kwargs: Any,
-    ) -> PredictionImageResult:
-        # if predict_image is implemented, route slice predictions to predict_image by default
-        if "image" in self.get_supported_modes():
-            # transform volume resources into 2D image resources for predict_image
-            image_inputs = []
-            # volume_cache = CacheManager(
-            #     'sliced_volumes',
-            #     enable_memory_cache=True,
-            #     memory_cache_maxsize=2,
-            # )
-            for r in model_input:
-                if isinstance(r, VolumeResource):
-                    image_inputs.append(SlicedVolumeResource(r,
-                                                             slice_index=slice_index,
-                                                             slice_axis=axis)
-                                        )
-                else:
-                    raise ValueError(f"Unsupported resource type for slice prediction: {type(r)}")
-
-            return self.predict_image(image_inputs, **kwargs)
-        raise NotImplementedError("predict_slice is not implemented")
 
     # ------------------------------------------------------------------
     # Serialization — also clears loader cache on restore

--- a/datamint/mlflow/flavors/prediction_router.py
+++ b/datamint/mlflow/flavors/prediction_router.py
@@ -25,6 +25,19 @@ class ModeSpec:
     fallback_to_default: bool = True
 
 
+def bridge_mode(fn: Callable) -> Callable:
+    """Marks a method as a bridge implementation.
+
+    Bridge methods are only auto-registered in the router when their
+    prerequisite mode is already in the registry (see
+    ``PredictionRouter._BRIDGE_MODE_PREREQS``).  Without this marker the
+    router would treat them as ordinary overrides and expose them regardless
+    of whether the prerequisite is implemented.
+    """
+    fn._is_bridge = True  # type: ignore[attr-defined]
+    return fn
+
+
 def prediction_mode(
     mode: PredictionMode,
     *,
@@ -65,6 +78,12 @@ class PredictionRouter:
     _RESERVED_PARAMS = frozenset({"mode", "confidence_threshold"})
     _DELEGATED_MODE_MAP = {
         PredictionMode.IMAGE: PredictionMode.SLICE,
+    }
+    # prerequisite → bridge modes that become available when prerequisite is registered
+    _BRIDGE_MODE_PREREQS: dict[PredictionMode, PredictionMode] = {
+        PredictionMode.VOLUME: PredictionMode.SLICE,
+        PredictionMode.FRAME: PredictionMode.IMAGE,
+        PredictionMode.ALL_FRAMES: PredictionMode.IMAGE,
     }
 
     def __init__(self, model_instance: Any,
@@ -116,6 +135,27 @@ class PredictionRouter:
                         source_mode.value, target_mode.value
                     )
                     registry[source_mode] = (method, ModeSpec(mode=source_mode))
+
+        # Step 4: register bridge modes when their prerequisite is in the registry.
+        # Bridge methods are marked with @bridge_mode; they are skipped in Pass 2
+        # (as base-class methods) and only activated here when the prerequisite mode
+        # is actually implemented.
+        for bridge_mode_key, prereq_mode in PredictionRouter._BRIDGE_MODE_PREREQS.items():
+            if bridge_mode_key in registry:
+                continue
+            if prereq_mode not in registry:
+                continue
+            method_name = f"predict_{bridge_mode_key.value}"
+            method = getattr(model, method_name, None)
+            if method is None:
+                continue
+            method_func = getattr(method, "__func__", method)
+            if getattr(method_func, "_is_bridge", False):
+                _LOGGER.info(
+                    "Registering bridge handler for '%s' mode (prereq: '%s')",
+                    bridge_mode_key.value, prereq_mode.value,
+                )
+                registry[bridge_mode_key] = (method, ModeSpec(mode=bridge_mode_key))
 
         return registry
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -35,6 +35,7 @@ Deployment
 * `01_deploy_registered_model.ipynb <https://github.com/SonanceAI/datamint-python-api/blob/main/notebooks/05_deployment/01_deploy_registered_model.ipynb>`_: Deploy a model registered in MLflow as a managed Datamint endpoint.
 * `02_deploy_external_model.ipynb <https://github.com/SonanceAI/datamint-python-api/blob/main/notebooks/05_deployment/02_deploy_external_model.ipynb>`_: Adapt and deploy an externally-trained model in Datamint.
 * `03_validate_model.ipynb <https://github.com/SonanceAI/datamint-python-api/blob/main/notebooks/05_deployment/03_validate_model.ipynb>`_: Validate a model before promoting it to production.
+* `04_predict_images_volumes_and_videos.ipynb <https://github.com/SonanceAI/datamint-python-api/blob/main/notebooks/05_deployment/04_predict_images_volumes_and_videos.ipynb>`_: Run a 2D model on images, 3D volumes, and video frames using automatic prediction bridges.
 
 End-to-End Examples
 -------------------

--- a/notebooks/05_deployment/04_predict_images_volumes_and_videos.ipynb
+++ b/notebooks/05_deployment/04_predict_images_volumes_and_videos.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Running Predictions on Images, Volumes, and Videos\n",
+    "\n",
+    "You trained a 2D segmentation model on plain PNG images.\n",
+    "But what happens when someone sends a CT scan or a video clip to the server?\n",
+    "\n",
+    "Datamint handles this automatically. If your model implements `predict_image`,\n",
+    "the library unlocks all of these modes without any extra code from you:\n",
+    "\n",
+    "| Mode | Input | What happens |\n",
+    "|---|---|---|\n",
+    "| `image` | PNG / JPEG | your model receives the image directly |\n",
+    "| `slice` | 3D volume | one axial slice is extracted → your model receives it as a 2D image |\n",
+    "| `volume` | 3D volume (CT, MRI) | every axial slice is processed → your model is called once per slice |\n",
+    "| `frame` | video | one frame is extracted → your model receives it as a 2D image |\n",
+    "| `all_frames` | video | every frame is processed → your model is called once per frame |\n",
+    "\n",
+    "This notebook shows all of this in action using a real model trained on breast ultrasound images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/luan/Desktop/Datamint/Codes/datamint-python-api/datamint/env/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"max-width: 720px; margin: 10px 0; overflow: hidden; border-radius: 18px;\n",
+       "           border: 1px solid var(--vscode-panel-border, #d0d7de);\n",
+       "           background: var(--vscode-editor-background, #ffffff);\n",
+       "           color: var(--vscode-foreground, #1f2328);\n",
+       "           box-shadow: 0 10px 30px rgba(15, 23, 42, 0.10);\">\n",
+       "\n",
+       "  \n",
+       "  <div style=\"padding: 18px 20px;\n",
+       "             border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\n",
+       "             background: linear-gradient(135deg, rgba(59, 130, 246, 0.14), rgba(16, 185, 129, 0.08));\">\n",
+       "    <div style=\"font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;\n",
+       "               color: var(--vscode-descriptionForeground, #57606a);\">Entity</div>\n",
+       "    <div style=\"display: flex; align-items: center; justify-content: space-between;\n",
+       "               gap: 12px; flex-wrap: wrap; margin-top: 8px;\">\n",
+       "      <h4 style=\"margin: 0; font-size: 22px; font-weight: 700; color: inherit;\">Project</h4>\n",
+       "    </div>\n",
+       "  </div>\n",
+       "\n",
+       "  \n",
+       "  <div style=\"padding: 12px 20px 18px;\">\n",
+       "    <table style=\"width: 100%; border-collapse: collapse; font-size: 14px;\">\n",
+       "      <tr>\n",
+       "        <th style=\"padding: 10px 12px 10px 0; width: 30%; text-align: left; vertical-align: top;\n",
+       "                  font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;\n",
+       "                  color: var(--vscode-descriptionForeground, #57606a); white-space: nowrap;\">Name</th>\n",
+       "        <td style=\"padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\">\n",
+       "          <span style=\"display: inline-block; padding: 2px 8px; border-radius: 999px;\n",
+       "                      background: var(--vscode-textCodeBlock-background, #f6f8fa);\n",
+       "                      color: var(--vscode-textPreformat-foreground, var(--vscode-foreground, #1f2328));\n",
+       "                      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;\n",
+       "                      font-size: 13px;\"\n",
+       "          >deeplabv3plus_Segmentation_Tutorial</span>\n",
+       "        </td>\n",
+       "      </tr>\n",
+       "      <tr>\n",
+       "        <th style=\"padding: 10px 12px 10px 0; width: 30%; text-align: left; vertical-align: top;\n",
+       "                  font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;\n",
+       "                  color: var(--vscode-descriptionForeground, #57606a); white-space: nowrap;\">Created At</th>\n",
+       "        <td style=\"padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\">\n",
+       "          <span style=\"display: inline-block; padding: 2px 8px; border-radius: 999px;\n",
+       "                      background: var(--vscode-textCodeBlock-background, #f6f8fa);\n",
+       "                      color: var(--vscode-textPreformat-foreground, var(--vscode-foreground, #1f2328));\n",
+       "                      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;\n",
+       "                      font-size: 13px;\"\n",
+       "          >2026-06-01T12:48:44.168Z</span>\n",
+       "        </td>\n",
+       "      </tr>\n",
+       "      <tr>\n",
+       "        <th style=\"padding: 10px 12px 10px 0; width: 30%; text-align: left; vertical-align: top;\n",
+       "                  font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;\n",
+       "                  color: var(--vscode-descriptionForeground, #57606a); white-space: nowrap;\">Created By</th>\n",
+       "        <td style=\"padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\">\n",
+       "          <span style=\"display: inline-block; padding: 2px 8px; border-radius: 999px;\n",
+       "                      background: var(--vscode-textCodeBlock-background, #f6f8fa);\n",
+       "                      color: var(--vscode-textPreformat-foreground, var(--vscode-foreground, #1f2328));\n",
+       "                      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;\n",
+       "                      font-size: 13px;\"\n",
+       "          >lucasmello.research@gmail.com</span>\n",
+       "        </td>\n",
+       "      </tr>\n",
+       "      <tr>\n",
+       "        <th style=\"padding: 10px 12px 10px 0; width: 30%; text-align: left; vertical-align: top;\n",
+       "                  font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;\n",
+       "                  color: var(--vscode-descriptionForeground, #57606a); white-space: nowrap;\">Archived</th>\n",
+       "        <td style=\"padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\">\n",
+       "          <span style=\"display: inline-block; padding: 2px 8px; border-radius: 999px;\n",
+       "                      background: var(--vscode-textCodeBlock-background, #f6f8fa);\n",
+       "                      color: var(--vscode-textPreformat-foreground, var(--vscode-foreground, #1f2328));\n",
+       "                      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;\n",
+       "                      font-size: 13px;\"\n",
+       "          >False</span>\n",
+       "        </td>\n",
+       "      </tr>\n",
+       "      <tr>\n",
+       "        <th style=\"padding: 10px 12px 10px 0; width: 30%; text-align: left; vertical-align: top;\n",
+       "                  font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;\n",
+       "                  color: var(--vscode-descriptionForeground, #57606a); white-space: nowrap;\">Resource Count</th>\n",
+       "        <td style=\"padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border, #d0d7de);\">\n",
+       "          <span style=\"display: inline-block; padding: 2px 8px; border-radius: 999px;\n",
+       "                      background: var(--vscode-textCodeBlock-background, #f6f8fa);\n",
+       "                      color: var(--vscode-textPreformat-foreground, var(--vscode-foreground, #1f2328));\n",
+       "                      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;\n",
+       "                      font-size: 13px;\"\n",
+       "          >780</span>\n",
+       "        </td>\n",
+       "      </tr>\n",
+       "    </table>\n",
+       "  </div>\n",
+       "\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Project(id='6f0c4ccb-8dda-41c1-be60-144e4953270c', name='deeplabv3plus_Segmentation_Tutorial', created_at='2026-06-01T12:48:44.168Z', created_by='lucasmello.research@gmail.com', dataset_id='9c07a85d-7985-44b3-a46d-404be963024d', archived=False, resource_count=780, description='', most_recent_experiment=None, annotators=[], is_annotation_only=False, is_validation_reader_only=False, reader_study_count=0, can_annotate=False, can_review=False, can_validate=False, is_contributor_only=False)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from datamint import Api\n",
+    "import datamint.mlflow as datamint_mlflow\n",
+    "\n",
+    "PROJECT_NAME = 'deeplabv3plus_Segmentation_Tutorial'\n",
+    "MODEL_NAME   = 'deeplabv3plus_Segmentation_Tutorial'\n",
+    "\n",
+    "api = Api()\n",
+    "datamint_mlflow.set_project(PROJECT_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "load-header",
+   "metadata": {},
+   "source": [
+    "## 1. Load the Model\n",
+    "\n",
+    "We load the model from the MLflow registry. No deployment needed — inference runs locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "load-model",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading artifacts: 100%|██████████| 6/6 [01:04<00:00, 10.72s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model       : DeepLabV3PlusModule\n",
+      "Task type   : TaskType.IMAGE_SEGMENTATION\n",
+      "Modes       : ['image', 'frame', 'all_frames', 'slice', 'volume']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from datamint.mlflow import flavors as datamint_flavor\n",
+    "\n",
+    "model = datamint_flavor.load_model(f'models:/{MODEL_NAME}/latest')\n",
+    "\n",
+    "print('Model       :', type(model).__name__)\n",
+    "print('Task type   :', model.task_type)\n",
+    "print('Modes       :', model.get_supported_modes())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "modes-note",
+   "metadata": {},
+   "source": [
+    "The model source code only has `predict_image`.\n",
+    "The library automatically adds the other four modes — you should see something like:\n",
+    "```\n",
+    "Modes: ['image', 'frame', 'all_frames', 'slice', 'volume']\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "image-header",
+   "metadata": {},
+   "source": [
+    "## 2. Predict on a Plain Image\n",
+    "\n",
+    "This is the native case. The model receives a real PNG from the project and `predict_image` is called directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fetch-image",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "normal (93).png                      ImageResource\n",
+      "normal (94).png                      ImageResource\n",
+      "normal (96).png                      ImageResource\n"
+     ]
+    }
+   ],
+   "source": [
+    "resources = list(api.resources.get_list(project_name=PROJECT_NAME, limit=3))\n",
+    "\n",
+    "for r in resources:\n",
+    "    print(f'{r.filename:<35}  {type(r).__name__}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "image-predict",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resource   : normal (93).png\n",
+      "Annotations: 1\n",
+      "  class='benign'  mask shape=(578, 770)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/luan/Desktop/Datamint/Codes/datamint-python-api/datamint/env/lib/python3.12/site-packages/albumentations/core/transforms_interface.py:310: UserWarning: The image is already an RGB.\n",
+      "  target_function(ensure_contiguous_output(arg), **params),\n"
+     ]
+    }
+   ],
+   "source": [
+    "image_resource = resources[0]\n",
+    "\n",
+    "predictions = model.predict([image_resource], params={'mode': 'image'})\n",
+    "\n",
+    "print('Resource   :', image_resource.filename)\n",
+    "print('Annotations:', len(predictions[0]))\n",
+    "for ann in predictions[0]:\n",
+    "    print(f'  class={ann.name!r}  mask shape={ann.mask.shape}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "volume-header",
+   "metadata": {},
+   "source": [
+    "## 3. Predict on a 3D Volume\n",
+    "\n",
+    "Same model, different input. The `volume` mode splits the NIfTI into axial slices and\n",
+    "calls `predict_image` on each one. The results from all slices are merged and returned.\n",
+    "\n",
+    "We create a small synthetic volume here to keep the notebook self-contained.\n",
+    "In production this would be a real CT scan or MRI fetched from the project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "create-volume",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Is volume: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import nibabel as nib\n",
+    "import tempfile, os\n",
+    "from datamint.entities.resource import LocalResource\n",
+    "\n",
+    "# 64 x 64 x 10 volume — 10 axial slices\n",
+    "data = (np.random.rand(64, 64, 10) * 1000).astype(np.int16)\n",
+    "nib_img = nib.Nifti1Image(data, affine=np.eye(4))\n",
+    "\n",
+    "tmp = tempfile.NamedTemporaryFile(suffix='.nii', delete=False)\n",
+    "nib.save(nib_img, tmp.name)\n",
+    "\n",
+    "volume_resource = LocalResource(\n",
+    "    raw_data=open(tmp.name, 'rb').read(),\n",
+    "    filename='synthetic_volume.nii',\n",
+    ")\n",
+    "os.unlink(tmp.name)\n",
+    "\n",
+    "print('Is volume:', volume_resource.is_volume())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "volume-predict",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total annotations across all slices: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# mode='volume' → the bridge slices the volume and calls predict_image once per slice\n",
+    "volume_predictions = model.predict([volume_resource], params={'mode': 'volume'})\n",
+    "\n",
+    "print('Total annotations across all slices:', len(volume_predictions[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "slice-predict",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Annotations for slice 4: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# mode='slice' → run on a single specific axial slice\n",
+    "slice_predictions = model.predict(\n",
+    "    [volume_resource],\n",
+    "    params={'mode': 'slice', 'slice_index': 4, 'axis': 'axial'},\n",
+    ")\n",
+    "\n",
+    "print('Annotations for slice 4:', len(slice_predictions[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "volume-note",
+   "metadata": {},
+   "source": [
+    "> **Note:** each slice is processed independently — results are 2D annotations per slice,\n",
+    "> not a merged 3D segmentation. If you need true 3D inference (e.g. NNUNet),\n",
+    "> you implement `predict_volume` directly and the bridge is bypassed entirely."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "video-header",
+   "metadata": {},
+   "source": [
+    "## 4. Predict on a Video\n",
+    "\n",
+    "Same idea as volumes but across the time axis. Each frame is extracted and sent to `predict_image`.\n",
+    "\n",
+    "This requires a `VideoResource` fetched from the API (it carries the frame count needed to iterate).\n",
+    "The example below shows what the code looks like — run it once you have a video in your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "video-predict",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch a video resource from the project\n",
+    "# video_resources = list(api.resources.get_list(\n",
+    "#     project_name=PROJECT_NAME,\n",
+    "#     mimetype_prefix='video/',\n",
+    "#     limit=1,\n",
+    "# ))\n",
+    "# video_resource = video_resources[0]\n",
+    "#\n",
+    "# # Run on every frame\n",
+    "# predictions = model.predict([video_resource], params={'mode': 'all_frames'})\n",
+    "# print('Annotations across all frames:', len(predictions[0]))\n",
+    "#\n",
+    "# # Or run on one specific frame\n",
+    "# predictions = model.predict([video_resource], params={'mode': 'frame', 'frame_index': 0})\n",
+    "# print('Annotations for frame 0:', len(predictions[0]))\n",
+    "\n",
+    "print('Uncomment the cells above once you have a video resource in the project.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deployed-header",
+   "metadata": {},
+   "source": [
+    "## 5. How This Works When the Model Is Deployed\n",
+    "\n",
+    "Everything above runs the same way on the Datamint server.\n",
+    "When a resource is sent to a deployed model, the server calls `.predict()` with the appropriate mode\n",
+    "— the bridge logic is the same whether you are running locally or on the server.\n",
+    "\n",
+    "To deploy this model, see `01_deploy_registered_model.ipynb`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/05_deployment/README.md
+++ b/notebooks/05_deployment/README.md
@@ -6,3 +6,5 @@ Deploying models as Docker images for remote inference.
 |---|---|
 | [01_deploy_registered_model](01_deploy_registered_model.ipynb) | Start, monitor, and cancel deployment jobs for a model already registered in Datamint |
 | [02_deploy_external_model](02_deploy_external_model.ipynb) | Wrap a model trained outside Datamint in a `DatamintModel` adapter and deploy it |
+| [03_validate_model](03_validate_model.ipynb) | Validate a model before promoting it to production |
+| [04_predict_images_volumes_and_videos](04_predict_images_volumes_and_videos.ipynb) | Run a 2D model on images, 3D volumes, and video frames using automatic prediction bridges |

--- a/notebooks/06_end_to_end/slice_based/02_busi_segmentation.ipynb
+++ b/notebooks/06_end_to_end/slice_based/02_busi_segmentation.ipynb
@@ -48,11 +48,20 @@
    "execution_count": null,
    "id": "ca7b0298",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/luan/Desktop/Datamint/Codes/datamint-python-api/datamint/env/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from datamint import Api\n",
     "\n",
-    "PROJECT_NAME = \"UNetPP_Segmentation_Tutorial\"\n",
+    "PROJECT_NAME = \"Segmentation_Tutorial\"\n",
     "api = Api()"
    ]
   },
@@ -167,7 +176,7 @@
        "</div>"
       ],
       "text/plain": [
-       "Project(id='6f0c4ccb-8dda-41c1-be60-144e4953270c', name='deeplabv3plus_Segmentation_Tutorial', created_at='2026-06-01T12:48:44.168Z', created_by='lucasmello.research@gmail.com', dataset_id='9c07a85d-7985-44b3-a46d-404be963024d', archived=False, resource_count=780, description='', most_recent_experiment=None, annotators=[], is_annotation_only=False)"
+       "Project(id='6f0c4ccb-8dda-41c1-be60-144e4953270c', name='deeplabv3plus_Segmentation_Tutorial', created_at='2026-06-01T12:48:44.168Z', created_by='lucasmello.research@gmail.com', dataset_id='9c07a85d-7985-44b3-a46d-404be963024d', archived=False, resource_count=780, description='', most_recent_experiment=None, annotators=[], is_annotation_only=False, is_validation_reader_only=False, reader_study_count=0, can_annotate=False, can_review=False, can_validate=False, is_contributor_only=False)"
       ]
      },
      "execution_count": 2,
@@ -422,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "2c596cd9",
    "metadata": {},
    "outputs": [],
@@ -435,7 +444,7 @@
     "    project=PROJECT_NAME,\n",
     "    image_size=256,\n",
     "    batch_size=16,\n",
-    "    max_epochs=3,\n",
+    "    max_epochs=5,\n",
     "    accelerator='auto',\n",
     "    # model_name='MyModelName' # Default is project name\n",
     ")"
@@ -480,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "263393ab",
    "metadata": {},
    "outputs": [],
@@ -493,8 +502,8 @@
     "    project=PROJECT_NAME,\n",
     "    # image_size is omitted — TransUNetTrainer always uses 224×224.\n",
     "    # Passing any other value raises a ValueError.\n",
-    "    batch_size=3,\n",
-    "    max_epochs=1,\n",
+    "    batch_size=16,\n",
+    "    max_epochs=5,\n",
     "    pretrained=True,   # loads ImageNet-21k pre-trained R50+ViT-B/16 weights\n",
     "    accelerator='cpu',\n",
     ")"

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -36,6 +36,8 @@ Folders are numbered in the recommended learning order.
 ### 05 — Deployment
 1. [`01_deploy_registered_model`](05_deployment/01_deploy_registered_model.ipynb) — Deploy a model already registered in Datamint
 2. [`02_deploy_external_model`](05_deployment/02_deploy_external_model.ipynb) — Wrap and deploy a model trained outside Datamint
+3. [`03_validate_model`](05_deployment/03_validate_model.ipynb) — Validate a model before promoting it to production
+4. [`04_predict_images_volumes_and_videos`](05_deployment/04_predict_images_volumes_and_videos.ipynb) — Run a 2D model on images, 3D volumes, and video frames using automatic prediction bridges
 
 ### 06 — End-to-End Use Cases
 


### PR DESCRIPTION
> Added support for multiple prediction modes via predict_image: image, slice, volume, frame and all frames
> Added step 4 to PredictionRouter.discover()
> Moved predict_slice from DatamintModel to BaseDatamintModel
> Added predict_volume, predict_frame, predict_all_frames
> Added override to SlicedVolumeResource.fetch_file_data()
> Added fallbacks to sliced_resource_base._get_version_info()
> Added notebook "predict_images_volumes_and_videos"
> Updated README.md and tutorials.rst

Closes DAT-828.