### PR TITLE
Symbolic files gives error when reading mimetype (DAT-655)

### DIFF
--- a/datamint/api/endpoints/resources_api.py
+++ b/datamint/api/endpoints/resources_api.py
@@ -292,6 +292,8 @@ class ResourcesApi(CreatableEntityApi[Resource], DeletableEntityApi[Resource]):
         else:
             source_filepath = os.path.abspath(os.path.expanduser(file_path))
             filename = os.path.basename(source_filepath)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"File not found: {file_path}")
 
         if session is not None and not isinstance(session, aiohttp.ClientSession):
             raise ValueError("session must be an aiohttp.ClientSession object.")

--- a/datamint/client_cmd_tools/datamint_upload.py
+++ b/datamint/client_cmd_tools/datamint_upload.py
@@ -216,6 +216,10 @@ def walk_to_depth(path: str | Path,
         if _is_system_file(child):
             continue
 
+        if child.is_symlink() and not child.exists():
+            _USER_LOGGER.warning(f"Skipping broken symlink: {child}")
+            continue
+
         if child.is_dir():
             if depth != 0:
                 if exclude_pattern is not None and fnmatch.fnmatch(child.name, exclude_pattern):


### PR DESCRIPTION
> Updated resources_api.py adding "os.path.exists()"
> Updated datamint_upload.py to skip broken symlinks

Closes DAT-655.